### PR TITLE
Patch the v0.14.1 opam release with a byte code fix.

### DIFF
--- a/src/bits_stubs.c
+++ b/src/bits_stubs.c
@@ -35,7 +35,7 @@ CAMLprim value hardcaml_bits_mask(intnat width, value vdst) {
 }
 
 CAMLprim value hardcaml_bits_mask_bc(value width, value vdst) {
-  return hardcaml_bits_mask(Val_int(width), vdst);
+  return hardcaml_bits_mask(Int_val(width), vdst);
 }
 
 /* Add two multiword [Bits.t].  The widths of the arguments and results are the same.


### PR DESCRIPTION
The masking function called for bytecode in bits_stubs.c calls the wrong
value conversion function, and basically breaks the bits api.

This patches it to call the correct function.

The native code was correct.