### PR TITLE
Add function to create named ram

### DIFF
--- a/src/ram.ml
+++ b/src/ram.ml
@@ -66,10 +66,15 @@ let if_read_before_write_mode ~collision_mode (r : Read_port.t array) (q : Signa
       Signal.reg (Reg_spec.create () ~clock:r.read_clock) ~enable:r.read_enable q)
 ;;
 
-let create ~collision_mode ~size ~write_ports ~read_ports =
+let create_named ?name ~collision_mode ~size ~write_ports ~read_ports () =
   Signal.multiport_memory
+    ?name
     size
     ~write_ports
     ~read_addresses:(if_write_before_read_mode ~collision_mode read_ports)
   |> if_read_before_write_mode ~collision_mode read_ports
+;;
+
+let create ~collision_mode ~size ~write_ports ~read_ports =
+  create_named ~collision_mode ~size ~write_ports ~read_ports ()
 ;;

--- a/src/ram.mli
+++ b/src/ram.mli
@@ -33,6 +33,16 @@ module Read_port : sig
   [@@deriving sexp_of]
 end
 
+(** create RAM with a name *)
+val create_named
+  :  ?name:string
+  -> collision_mode:Collision_mode.t
+  -> size:int
+  -> write_ports:Write_port.t array
+  -> read_ports:Read_port.t array
+  -> unit
+  -> Signal.t array
+
 val create
   :  collision_mode:Collision_mode.t
   -> size:int

--- a/test/lib/test_multiport_memory.ml
+++ b/test/lib/test_multiport_memory.ml
@@ -286,7 +286,8 @@ let%expect_test "verilog, async memory, 2 ports" =
 
 let dual_port ?(collision_mode = Ram.Collision_mode.Read_before_write) () =
   let read_data =
-    Ram.create
+    Ram.create_named
+      ~name:"named_ram"
       ~collision_mode
       ~size:32
       ~write_ports:
@@ -311,6 +312,7 @@ let dual_port ?(collision_mode = Ram.Collision_mode.Read_before_write) () =
            ; read_enable = Signal.input "read_enable2" 1
            }
         |]
+      ()
   in
   Circuit.create_exn
     ~name:"multi_port_memory"
@@ -366,25 +368,25 @@ let%expect_test "dual port Verilog" =
         reg [14:0] _21;
         wire [14:0] _24 = 15'b000000000000000;
         wire [14:0] _23 = 15'b000000000000000;
-        reg [14:0] _17[0:31];
+        reg [14:0] named_ram[0:31];
         wire [14:0] _22;
         reg [14:0] _25;
 
         /* logic */
-        assign _18 = _17[read_address2];
+        assign _18 = named_ram[read_address2];
         always @(posedge read_clock2) begin
             if (read_enable2)
                 _21 <= _18;
         end
         always @(posedge write_clock1) begin
             if (write_enable1)
-                _17[write_address1] <= write_data1;
+                named_ram[write_address1] <= write_data1;
         end
         always @(posedge write_clock2) begin
             if (write_enable2)
-                _17[write_address2] <= write_data2;
+                named_ram[write_address2] <= write_data2;
         end
-        assign _22 = _17[read_address1];
+        assign _22 = named_ram[read_address1];
         always @(posedge read_clock1) begin
             if (read_enable1)
                 _25 <= _22;
@@ -451,15 +453,15 @@ let%expect_test "dual port VHDL" =
         signal hc_21 : std_logic_vector (14 downto 0);
         constant hc_24 : std_logic_vector (14 downto 0) := "000000000000000";
         constant hc_23 : std_logic_vector (14 downto 0) := "000000000000000";
-        type hc_17_type is array (0 to 31) of std_logic_vector(14 downto 0);
-        signal hc_17 : hc_17_type;
+        type named_ram_type is array (0 to 31) of std_logic_vector(14 downto 0);
+        signal named_ram : named_ram_type;
         signal hc_22 : std_logic_vector (14 downto 0);
         signal hc_25 : std_logic_vector (14 downto 0);
 
     begin
 
         -- logic
-        hc_18 <= hc_17(to_integer(hc_uns(read_address2)));
+        hc_18 <= named_ram(to_integer(hc_uns(read_address2)));
         process (read_clock2) begin
             if rising_edge(read_clock2) then
                 if read_enable2 = '1' then
@@ -470,18 +472,18 @@ let%expect_test "dual port VHDL" =
         process (write_clock1) begin
             if rising_edge(write_clock1) then
                 if write_enable1 = '1' then
-                    hc_17(to_integer(hc_uns(write_address1))) <= write_data1;
+                    named_ram(to_integer(hc_uns(write_address1))) <= write_data1;
                 end if;
             end if;
         end process;
         process (write_clock2) begin
             if rising_edge(write_clock2) then
                 if write_enable2 = '1' then
-                    hc_17(to_integer(hc_uns(write_address2))) <= write_data2;
+                    named_ram(to_integer(hc_uns(write_address2))) <= write_data2;
                 end if;
             end if;
         end process;
-        hc_22 <= hc_17(to_integer(hc_uns(read_address1)));
+        hc_22 <= named_ram(to_integer(hc_uns(read_address1)));
         process (read_clock1) begin
             if rising_edge(read_clock1) then
                 if read_enable1 = '1' then


### PR DESCRIPTION
The function to create synchronous memory (the one defined in the Ram module) does not support naming that memory. This name would be especially helpful in debugging and reading reports when using synthesis tools.

This PR extends the interface of the Ram module by a new function `create_named`. I haven't found a way to modify the existing function without breaking backward compatibility. 