### PR TITLE
Update README.md to fix API Docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ opam install hardcaml ppx_hardcaml hardcaml_waveterm
 # Documentation
 
 * [Manual](https://github.com/janestreet/hardcaml/blob/master/docs/index.md)
-* [API Docs](https://v3.ocaml.org/p/hardcaml/v0.15.0/doc/Hardcaml/index.html)
+* [API Docs](https://ocaml.org/p/hardcaml/v0.15.0/doc/Hardcaml/index.html)
 
 # Tools and libraries
 


### PR DESCRIPTION
Fix README.md API Docs link

Current API Docs link redirects to OCaml home page and not to the API Docs. 

Removing the subdomain v3 on the link seems to fix this.

This was tested on both my computer and my phone to confirm but in both cases it appears to not link properly without removing the subdomain.