### PR TITLE
Escape Yosys-reserved words in Verilog

### DIFF
--- a/src/reserved_words.ml
+++ b/src/reserved_words.ml
@@ -345,7 +345,9 @@ let systemverilog =
        illegal_bins
        shortreal
        bit
+       implements
        implies
+       soft
        solve
        break
        import
@@ -360,6 +362,7 @@ let systemverilog =
        interface
        struct
        class
+       interconnect
        intersect
        super
        clocking
@@ -387,6 +390,7 @@ let systemverilog =
        modport
        type
        cross
+       nettype
        new
        typedef
        dist
@@ -406,7 +410,7 @@ let systemverilog =
        until_with
        endgroup
        program
-       untypted
+       untyped
        endinterface
        property
        var

--- a/src/rtl_name.ml
+++ b/src/rtl_name.ml
@@ -23,7 +23,9 @@ end
 
 module Verilog = struct
   module Verilog_base = Make_verilog (struct
-      let reserved_words = Reserved_words.verilog
+      (* Yosys reserves IEEE 1800 keywords in its Verilog output. Use the same superset
+         so generated netlists remain compatible with its parser. *)
+      let reserved_words = Reserved_words.systemverilog
     end)
 
   include Verilog_base

--- a/test/lib/test_rtl_gen.ml
+++ b/test/lib/test_rtl_gen.ml
@@ -556,9 +556,9 @@ let%expect_test "initial value of resisters with comment (only in Verilog)" =
     |}]
 ;;
 
-let%expect_test "detects system verilog keyword" =
+let%expect_test "escapes system verilog keywords in Yosys-compatible Verilog" =
   let circuit =
-    Circuit.create_exn ~name:"test" [ output "q" (wireof (input "d" 1) -- "virtual") ]
+    Circuit.create_exn ~name:"test" [ output "q" (wireof (input "d" 1) -- "dist") ]
   in
   Rtl.print Verilog circuit;
   [%expect
@@ -571,9 +571,9 @@ let%expect_test "detects system verilog keyword" =
         input d;
         output q;
 
-        wire virtual;
-        assign virtual = d;
-        assign q = virtual;
+        wire \dist ;
+        assign \dist  = d;
+        assign q = \dist ;
 
     endmodule
     |}];
@@ -588,9 +588,9 @@ let%expect_test "detects system verilog keyword" =
         input d;
         output q;
 
-        wire \virtual ;
-        assign \virtual  = d;
-        assign q = \virtual ;
+        wire \dist ;
+        assign \dist  = d;
+        assign q = \dist ;
 
     endmodule
     |}];
@@ -610,12 +610,12 @@ let%expect_test "detects system verilog keyword" =
 
     architecture rtl of test is
 
-        signal virtual : std_logic;
+        signal dist : std_logic;
 
     begin
 
-        virtual <= d;
-        q <= virtual;
+        dist <= d;
+        q <= dist;
 
     end architecture;
     |}]


### PR DESCRIPTION
## Summary
- use the IEEE 1800 keyword superset when legalizing Verilog identifiers so emitted netlists remain compatible with Yosys
- add the four current Yosys keywords missing from the SystemVerilog table and fix the `untyped` spelling
- update the RTL expect regression to cover the reported `dist` identifier in Verilog, SystemVerilog, and VHDL output

Fixes #21

## Correctness
Yosys applies its SystemVerilog keyword table while emitting Verilog. Using the same superset for Hardcaml's Verilog legalization ensures names rejected by Yosys are escaped before they reach the backend. VHDL legalization is unchanged.

## Validation
- `git diff --check`
- private Linux comparison script extracted Hardcaml's SystemVerilog table and Yosys [`verilog_keywords()`](https://github.com/YosysHQ/yosys/blob/main/backends/verilog/verilog_backend.cc#L41-L67): matched all 248 keywords with no missing or extra entries
- checked the focused expect fixture for escaped Verilog `\dist` declarations and assignments while VHDL remains `dist`
- full Dune validation could not start from the public source because the current dependency set includes unpublished package `ppx_rope`
